### PR TITLE
chore: adapt to libschrift 0.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ requirements:
 * Optionally `make` for install script and such
 * [utf8proc](https://juliastrings.github.io/utf8proc)
 * [harfbuzz](harfbuzz.github.io/)
-* [libschrift](https://github.com/tomolt/libschrift) == 0.10.0
+* [libschrift](https://github.com/tomolt/libschrift) == 0.10.1
 
 ```
 # run inside nix-shell if you have nix!

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,7 @@
 { pkgs ? import <nixpkgs> { } }:
 
+assert pkgs.lib.versionAtLeast pkgs.libschrift.version "0.10.1";
+
 let
   gi = pkgs.nix-gitignore;
 


### PR DESCRIPTION
sft_extents and sft_hmetrics have been unified into sft_gmetrics which
requires a bit of code shuffling, but nothing too dramatic. As a result,
we no longer support libschrift 0.10.0.

cc @jkammerl, this version now also finally has a tag in the upstream repository.